### PR TITLE
Defered LockServiceProvider

### DIFF
--- a/src/LockServiceProvider.php
+++ b/src/LockServiceProvider.php
@@ -9,6 +9,13 @@ use Illuminate\Support\ServiceProvider;
 class LockServiceProvider extends ServiceProvider
 {
     /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
      * Bootstrap the service provider
      */
     public function boot()


### PR DESCRIPTION
```$app['auth']->check()``` is alway ```null``` (at https://github.com/BeatSwitch/lock-laravel/blob/9cb25c01e31e0f6febacf8519560ae2b033ffbcf/src/LockServiceProvider.php#L90) if not defered, ```Auth``` as not booted.

you need to update storage/framework/service.json with ```php artisan optimize```