### PR TITLE
Fixed: default Lock not getting the right user

### DIFF
--- a/src/LockServiceProvider.php
+++ b/src/LockServiceProvider.php
@@ -110,7 +110,7 @@ class LockServiceProvider extends ServiceProvider
 
         // Add the permissions which were set in the config file.
         if (! is_null($callback)) {
-            call_user_func($callback, $this->app['lock.manager'], $this->app['lock']);
+            call_user_func($callback, $this->app['lock.manager']);
         }
     }
 


### PR DESCRIPTION
Botstrapping permissions resolves `lock` which checks the user, but since this is done when booting the service provider, session is not fullfilled yet and user is not resolved, so default lock always gets guest users.
