### PR TITLE
Changed the class called to use the ::class syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ composer require beatswitch/lock-laravel
 Register the service provider in your `app.php` config file.
 
 ```php
-'BeatSwitch\Lock\Integrations\Laravel\LockServiceProvider',
+BeatSwitch\Lock\Integrations\Laravel\LockServiceProvider::class,
 ```
 
 Register the facades in your `app.php` config file.


### PR DESCRIPTION
As of laravel 5.1 the ::class method is beeing used for the class references.